### PR TITLE
Add parameter inlays

### DIFF
--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -10,6 +10,8 @@ import com.intellij.codeInsight.hints.Option
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.types.findTy
+import org.elm.lang.core.types.renderedText
 
 @Suppress("UnstableApiUsage")
 object ElmInlayParameterHints {
@@ -25,6 +27,11 @@ object ElmInlayParameterHints {
 
     @ExperimentalStdlibApi
     fun provideHints(elem: PsiElement): List<InlayInfo> {
+        if (elem is ElmAnonymousFunctionExpr) {
+            return elem.namedParameters.map { param ->
+                InlayInfo(": " + param.findTy()?.renderedText(), param.endOffset)
+            }
+        }
         val (callInfo, valueArgumentList) = when (elem) {
             is ElmFunctionCallExpr -> ( elem.target.reference?.resolve() to elem)
             else -> return emptyList()

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -45,7 +45,6 @@ object ElmInlayParameterHints {
                         return@map InlayInfo("$asText:", arg.startOffset)
                     }
                     when (param) {
-                        is ElmRecordPattern -> null
                         is ElmAnythingPattern -> null
                         is ElmPattern -> {
                             val child = param.unwrapped

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -64,6 +64,9 @@ object ElmInlayParameterHints {
                                 emptyList()
                             }
                         }
+                        is ElmUnitExpr -> {
+                            emptyList()
+                        }
                         is ElmUnionPattern -> {
 //                                listOf(InlayInfo(unwrapped.upperCaseQID.fullName + ":", arg.startOffset))
                             emptyList()

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -39,13 +39,27 @@ object ElmInlayParameterHints {
         val hints = elements.zip(valueArgumentList.arguments.toList())
 
         return hints
-                .filter { (param, arg) ->
+                .map { (param, arg) ->
                     when (param) {
-                        is ElmRecordPattern -> false
-                        is ElmAnythingPattern -> false
-                        else -> true
+                        is ElmRecordPattern -> null
+                        is ElmAnythingPattern -> null
+                        is ElmPattern -> {
+                            val child = param.child
+                            if (child is ElmUnionPattern) {
+                                if (child.argumentPatterns.count() == 1) {
+                                    InlayInfo(child.argumentPatterns.first().text + ":", arg.startOffset)
+                                } else {
+                                    null
+                                }
+                            } else {
+                                InlayInfo(param.text + ":", arg.startOffset)
+                            }
+                        }
+                        else -> {
+                            InlayInfo(param.text + ":", arg.startOffset)
+                        }
                     }
                 }
-                .map { (hint, arg) -> InlayInfo(hint.text + ":", arg.startOffset) }
+                .filterNotNull()
     }
 }

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -8,8 +8,7 @@ package org.elm.ide.hints.parameter
 import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.Option
 import com.intellij.psi.PsiElement
-import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
-import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
+import org.elm.lang.core.psi.elements.*
 import org.elm.lang.core.psi.startOffset
 
 @Suppress("UnstableApiUsage")
@@ -33,14 +32,20 @@ object ElmInlayParameterHints {
         if (callInfo == null) return emptyList()
         val elements =
                 if (callInfo is ElmFunctionDeclarationLeft) {
-                    callInfo.namedParameters.map {
-                        it.name
-                    }.toList()
+                    callInfo.patterns.toList()
                 } else {
                     emptyList()
                 }
         val hints = elements.zip(valueArgumentList.arguments.toList())
 
-        return hints.map { (hint, arg) -> InlayInfo("$hint:", arg.startOffset) }
+        return hints
+                .filter { (param, arg) ->
+                    when (param) {
+                        is ElmRecordPattern -> false
+                        is ElmAnythingPattern -> false
+                        else -> true
+                    }
+                }
+                .map { (hint, arg) -> InlayInfo(hint.text + ":", arg.startOffset) }
     }
 }

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -10,6 +10,7 @@ import com.intellij.codeInsight.hints.Option
 import com.intellij.psi.PsiElement
 import org.elm.lang.core.psi.*
 import org.elm.lang.core.psi.elements.*
+import org.elm.lang.core.types.TyUnknown
 import org.elm.lang.core.types.findTy
 import org.elm.lang.core.types.renderedText
 import org.elm.utils.getIndent
@@ -37,7 +38,12 @@ object ElmInlayParameterHints {
             is ElmLetInExpr -> {
                 return elem.valueDeclarationList.mapNotNull { param ->
                     if (param.typeAnnotation == null) {
-                        InlayInfo(" -- " + param.findTy()?.renderedText(), param.eqElement?.endOffset!!)
+                        val findTy = param.findTy()
+                        if (findTy is TyUnknown || findTy == null) {
+                            null
+                        } else {
+                            InlayInfo(" -- " + findTy.renderedText(), param.eqElement?.endOffset!!)
+                        }
                     } else {
                         null
                     }

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -48,7 +48,7 @@ object ElmInlayParameterHints {
                         is ElmRecordPattern -> null
                         is ElmAnythingPattern -> null
                         is ElmPattern -> {
-                            val child = param.child
+                            val child = param.unwrapped
                             if (child is ElmUnionPattern) {
                                 InlayInfo(child.upperCaseQID.fullName + ":", arg.startOffset)
                             } else {

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -52,6 +52,7 @@ object ElmInlayParameterHints {
                     }
                     when (unwrapped) {
                         is ElmAnythingPattern -> emptyList()
+                        is ElmRecordPattern -> emptyList()
                         is ElmTuplePattern -> {
                             if (arg is ElmTupleExpr) {
                                 unwrapped.patternList.zip(arg.expressionList).map { (tupleParam, tupleArg) ->

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -22,11 +22,6 @@ object ElmInlayParameterHints {
     val enabledOption: Option = Option("SHOW_PARAMETER_HINT", "Show argument name hints", true)
     val enabled: Boolean get() = enabledOption.get()
 
-    // BACKCOMPAT: 2020.1
-    @Suppress("DEPRECATION")
-    val smartOption: Option = Option("SMART_HINTS", "Show only smart hints", true)
-    val smart: Boolean get() = smartOption.get()
-
     @ExperimentalStdlibApi
     fun provideHints(elem: PsiElement): List<InlayInfo> {
         return when (elem) {

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -50,11 +50,7 @@ object ElmInlayParameterHints {
                         is ElmPattern -> {
                             val child = param.child
                             if (child is ElmUnionPattern) {
-                                if (child.argumentPatterns.count() == 1) {
-                                    InlayInfo(child.argumentPatterns.first().text + ":", arg.startOffset)
-                                } else {
-                                    null
-                                }
+                                InlayInfo(child.upperCaseQID.fullName + ":", arg.startOffset)
                             } else {
                                 InlayInfo(param.text + ":", arg.startOffset)
                             }

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -57,13 +57,13 @@ object ElmInlayParameterHints {
                                 unwrapped.patternList.zip(arg.expressionList).map { (tupleParam, tupleArg) ->
                                     InlayInfo(tupleParam.text + ":", tupleArg.startOffset)
                                 }
-
                             } else {
                                 emptyList()
                             }
                         }
                         is ElmUnionPattern -> {
-                                listOf(InlayInfo(unwrapped.upperCaseQID.fullName + ":", arg.startOffset))
+//                                listOf(InlayInfo(unwrapped.upperCaseQID.fullName + ":", arg.startOffset))
+                            emptyList()
                         }
                         else -> {
                             listOf(InlayInfo(unwrapped.text + ":", arg.startOffset))

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -35,8 +35,12 @@ object ElmInlayParameterHints {
                 }
             }
             is ElmLetInExpr -> {
-                return elem.valueDeclarationList.map { param ->
-                    InlayInfo(" -- " + param.findTy()?.renderedText(), param.eqElement?.endOffset!!)
+                return elem.valueDeclarationList.mapNotNull { param ->
+                    if (param.typeAnnotation == null) {
+                        InlayInfo(" -- " + param.findTy()?.renderedText(), param.eqElement?.endOffset!!)
+                    } else {
+                        null
+                    }
                 }
             }
             else -> {

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -1,0 +1,46 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.elm.ide.hints.parameter
+
+import com.intellij.codeInsight.hints.InlayInfo
+import com.intellij.codeInsight.hints.Option
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
+import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
+import org.elm.lang.core.psi.startOffset
+
+@Suppress("UnstableApiUsage")
+object ElmInlayParameterHints {
+    // BACKCOMPAT: 2020.1
+    @Suppress("DEPRECATION")
+    val enabledOption: Option = Option("SHOW_PARAMETER_HINT", "Show argument name hints", true)
+    val enabled: Boolean get() = enabledOption.get()
+
+    // BACKCOMPAT: 2020.1
+    @Suppress("DEPRECATION")
+    val smartOption: Option = Option("SMART_HINTS", "Show only smart hints", true)
+    val smart: Boolean get() = smartOption.get()
+
+    @ExperimentalStdlibApi
+    fun provideHints(elem: PsiElement): List<InlayInfo> {
+        val (callInfo, valueArgumentList) = when (elem) {
+            is ElmFunctionCallExpr -> ( elem.target.reference?.resolve() to elem)
+            else -> return emptyList()
+        }
+        if (callInfo == null) return emptyList()
+        val elements =
+                if (callInfo is ElmFunctionDeclarationLeft) {
+                    callInfo.namedParameters.map {
+                        it.name
+                    }.toList()
+                } else {
+                    emptyList()
+                }
+        val hints = elements.zip(valueArgumentList.arguments.toList())
+
+        return hints.map { (hint, arg) -> InlayInfo("$hint:", arg.startOffset) }
+    }
+}

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -25,10 +25,8 @@ object ElmInlayParameterHints {
     @ExperimentalStdlibApi
     fun provideHints(elem: PsiElement): List<InlayInfo> {
         return when (elem) {
-            is ElmAnonymousFunctionExpr -> {
-                elem.namedParameters.map { param ->
-                    InlayInfo(": " + param.findTy()?.renderedText(), param.endOffset)
-                }
+            is ElmNameDeclarationPatternTag -> {
+                listOf(InlayInfo(": " + elem.findTy()?.renderedText(), elem.endOffset))
             }
             is ElmValueDeclaration -> {
                 return if (elem.typeAnnotation == null) {

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -36,25 +36,25 @@ object ElmInlayParameterHints {
                 } else {
                     emptyList()
                 }
-        val hints = elements.map {
-            if (it is ElmPattern ) {
-                it.unwrapped
-            } else {
-                it
-            }
-        }.zip(valueArgumentList.arguments.toList())
+        val hints = elements.zip(valueArgumentList.arguments.toList())
 
         return hints
                 .flatMap { (param, arg) ->
-                    val asText = ( param.parent as? ElmPattern )?.patternAs?.text
-                    if (asText != null) {
-                        return listOf(InlayInfo("$asText:", arg.startOffset))
+                    val unwrapped = if (param is ElmPattern ) {
+                        param.unwrapped
+                    } else {
+                        param
                     }
-                    when (param) {
+
+                    val asText = ( param as? ElmPattern )?.patternAs?.text
+                    if (asText != null) {
+                        return@flatMap listOf(InlayInfo("$asText:", arg.startOffset))
+                    }
+                    when (unwrapped) {
                         is ElmAnythingPattern -> emptyList()
                         is ElmTuplePattern -> {
                             if (arg is ElmTupleExpr) {
-                                param.patternList.zip(arg.expressionList).map { (tupleParam, tupleArg) ->
+                                unwrapped.patternList.zip(arg.expressionList).map { (tupleParam, tupleArg) ->
                                     InlayInfo(tupleParam.text + ":", tupleArg.startOffset)
                                 }
 
@@ -63,10 +63,10 @@ object ElmInlayParameterHints {
                             }
                         }
                         is ElmUnionPattern -> {
-                                listOf(InlayInfo(param.upperCaseQID.fullName + ":", arg.startOffset))
+                                listOf(InlayInfo(unwrapped.upperCaseQID.fullName + ":", arg.startOffset))
                         }
                         else -> {
-                            listOf(InlayInfo(param.text + ":", arg.startOffset))
+                            listOf(InlayInfo(unwrapped.text + ":", arg.startOffset))
                         }
                     }
                 }

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHints.kt
@@ -40,6 +40,10 @@ object ElmInlayParameterHints {
 
         return hints
                 .map { (param, arg) ->
+                    val asText = ( param as? ElmPattern )?.patternAs?.text
+                    if (asText != null) {
+                        return@map InlayInfo("$asText:", arg.startOffset)
+                    }
                     when (param) {
                         is ElmRecordPattern -> null
                         is ElmAnythingPattern -> null

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProvider.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProvider.kt
@@ -15,7 +15,7 @@ import com.intellij.psi.PsiElement
 @Suppress("UnstableApiUsage")
 class ElmInlayParameterHintsProvider : InlayParameterHintsProvider {
     override fun getSupportedOptions(): List<Option> =
-            listOf(ElmInlayParameterHints.enabledOption, ElmInlayParameterHints.smartOption)
+            listOf(ElmInlayParameterHints.enabledOption)
 
     override fun getDefaultBlackList(): Set<String> = emptySet()
 

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProvider.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProvider.kt
@@ -1,0 +1,58 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.elm.ide.hints.parameter
+
+import com.intellij.codeInsight.hints.HintInfo
+import com.intellij.codeInsight.hints.InlayInfo
+import com.intellij.codeInsight.hints.InlayParameterHintsProvider
+import com.intellij.codeInsight.hints.Option
+import com.intellij.psi.PsiElement
+import org.elm.lang.core.ElmLanguage
+import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
+import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
+
+
+@Suppress("UnstableApiUsage")
+class ElmInlayParameterHintsProvider : InlayParameterHintsProvider {
+    override fun getSupportedOptions(): List<Option> =
+            listOf(ElmInlayParameterHints.enabledOption, ElmInlayParameterHints.smartOption)
+
+    override fun getDefaultBlackList(): Set<String> = emptySet()
+
+    override fun getHintInfo(element: PsiElement): HintInfo? {
+        return when (element) {
+            is ElmFunctionCallExpr -> {
+                resolve(element)
+            }
+            else -> {
+                null
+            }
+        }
+    }
+
+    @ExperimentalStdlibApi
+    override fun getParameterHints(element: PsiElement): List<InlayInfo> {
+        if (ElmInlayParameterHints.enabled) {
+            return ElmInlayParameterHints.provideHints(element)
+        }
+        return emptyList()
+    }
+
+    override fun getInlayPresentation(inlayText: String): String = inlayText
+
+    companion object {
+        private fun resolve(call: ElmFunctionCallExpr): HintInfo.MethodInfo? {
+            val fn = (call.target).reference?.resolve() as? ElmFunctionDeclarationLeft ?: return null
+            val parameters = fn.namedParameters.map { it.text }
+            return createMethodInfo(fn, parameters)
+        }
+
+        private fun createMethodInfo(function: ElmFunctionDeclarationLeft, parameters: List<String>): HintInfo.MethodInfo? {
+            val path = function.name
+            return HintInfo.MethodInfo(path, parameters, ElmLanguage)
+        }
+    }
+}

--- a/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProvider.kt
+++ b/src/main/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProvider.kt
@@ -10,9 +10,6 @@ import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.InlayParameterHintsProvider
 import com.intellij.codeInsight.hints.Option
 import com.intellij.psi.PsiElement
-import org.elm.lang.core.ElmLanguage
-import org.elm.lang.core.psi.elements.ElmFunctionCallExpr
-import org.elm.lang.core.psi.elements.ElmFunctionDeclarationLeft
 
 
 @Suppress("UnstableApiUsage")
@@ -22,17 +19,6 @@ class ElmInlayParameterHintsProvider : InlayParameterHintsProvider {
 
     override fun getDefaultBlackList(): Set<String> = emptySet()
 
-    override fun getHintInfo(element: PsiElement): HintInfo? {
-        return when (element) {
-            is ElmFunctionCallExpr -> {
-                resolve(element)
-            }
-            else -> {
-                null
-            }
-        }
-    }
-
     @ExperimentalStdlibApi
     override fun getParameterHints(element: PsiElement): List<InlayInfo> {
         if (ElmInlayParameterHints.enabled) {
@@ -41,18 +27,12 @@ class ElmInlayParameterHintsProvider : InlayParameterHintsProvider {
         return emptyList()
     }
 
-    override fun getInlayPresentation(inlayText: String): String = inlayText
-
-    companion object {
-        private fun resolve(call: ElmFunctionCallExpr): HintInfo.MethodInfo? {
-            val fn = (call.target).reference?.resolve() as? ElmFunctionDeclarationLeft ?: return null
-            val parameters = fn.namedParameters.map { it.text }
-            return createMethodInfo(fn, parameters)
-        }
-
-        private fun createMethodInfo(function: ElmFunctionDeclarationLeft, parameters: List<String>): HintInfo.MethodInfo? {
-            val path = function.name
-            return HintInfo.MethodInfo(path, parameters, ElmLanguage)
-        }
+    override fun getHintInfo(element: PsiElement?): HintInfo? {
+        // Hint info is used to add function names to the exclude list
+        // since we're just doing type hints right now, it doesn't apply.
+        // It will apply if we add parameter name hints.
+        return null
     }
+
+    override fun getInlayPresentation(inlayText: String): String = inlayText
 }

--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmPattern.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmPattern.kt
@@ -15,6 +15,15 @@ class ElmPattern(node: ASTNode) : ElmPsiElementImpl(node), ElmFunctionParamTag, 
     val child: ElmPatternChildTag
         get() = findNotNullChildByClass(ElmPatternChildTag::class.java)
 
+    val unwrapped: ElmPatternChildTag
+        get() {
+            var nextChild = child
+            while (nextChild is ElmPattern) {
+                nextChild = nextChild.child
+            }
+            return nextChild
+        }
+
     /**
      * The name after the `as` that this pattern is bound to.
      *

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -317,6 +317,8 @@
         <backspaceHandlerDelegate implementation="org.elm.ide.typing.ElmBackspaceHandler"/>
         <codeInsight.parameterInfo language="Elm" implementationClass="org.elm.ide.hints.ElmParameterInfoHandler"/>
         <codeInsight.typeInfo language="Elm" implementationClass="org.elm.ide.hints.ElmExpressionTypeProvider"/>
+        <codeInsight.parameterNameHints language="Elm"
+                                        implementationClass="org.elm.ide.hints.parameter.ElmInlayParameterHintsProvider"/>
         <codeInsight.lineMarkerProvider language="Elm" implementationClass="org.elm.ide.lineMarkers.ElmLineMarkerProvider"/>
         <lang.smartEnterProcessor language="Elm" implementationClass="org.elm.ide.typing.ElmSmartEnterProcessor"/>
         <extendWordSelectionHandler implementation="org.elm.ide.wordSelection.ElmDeclAnnotationSelectionHandler"/>

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -135,6 +135,17 @@ example =
     foo
 """)
 
+    fun `test no hint for annotated let binding`() = checkByText("""module Foo exposing (..)
+
+example =
+    let
+        foo : List Float
+        foo =
+            1 :: [ 2.3 ]
+    in
+    foo
+""")
+
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -10,124 +10,16 @@ import org.elm.lang.ElmTestBase
 import org.intellij.lang.annotations.Language
 
 class ElmInlayParameterHintsProviderTest : ElmTestBase() {
-    fun `test fn args`() = checkByText("""module Foo exposing (..)
 
-greet first last = "Hello " ++ first ++ " " ++ last
-
-greeting =
-    greet {-hint text="first:"-}"Jane" {-hint text="last:"-}"Doe"
-
-""")
-
-    fun `test no hints for destructured record arguments`() = checkByText("""module Foo exposing (..)
+    fun `test type hint in lambda`() = checkByText("""module Foo exposing (..)
 
 example =
-    nameToString
-        { first = "Jane"
-        , last = "Doe"
-        }
-
-
-nameToString { first, last } =
-    first ++ " " ++ last
-""")
-
-    fun `test no hints for nested record destructuring`() = checkByText("""module Foo exposing (..)
-
-example =
-    nameToString ( (), { first = "Jane" , last = "Doe" } )
-
-
-nameToString (_, { first, last }) =
-    first ++ " " ++ last
-""")
-
-
-    fun `test no hints for discarded arguments`() = checkByText("""module Foo exposing (..)
-
-example =
-    getUserId token <hint text="retry:"/>True
-
-getUserId : Token -> Bool -> Cmd msg
-getUserId _ retry =
-    getUserIdHttpRequest retry
-""")
-
-    fun `test uses name from top-level as clause`() = checkByText("""module Foo exposing (..)
-example =
-    coordinatesToString {-hint text="coordinates:"-}( 1, 2 )
-
-coordinatesToString (( x, y ) as coordinates) =
-    String.fromInt x ++ ", " ++ String.fromInt y
-""")
-
-    fun `test uses variant name when destructuring custom type`() = checkByText("""module Foo exposing (..)
-
-type Element = Element Internals
-
-type alias Internals = { x: Int, y: Int }
-
-example value=
-    destructureVariant value
-
-
-destructureVariant (Element internals) =
-    "Example"
-""")
-
-    fun `test it discards nested parens in pattern expressions`() = checkByText("""module Foo exposing (..)
-
-example3 =
-    toString ( {-hint text="x:"-}123, {-hint text="y:"-}456)
-
-toString (((x,y))) =
-    String.fromInt x ++ ", " ++ String.fromInt y
-""")
-
-    fun `test show pattern matched value name inline`() = checkByText("""module Foo exposing (..)
-
-example3 user =
-    destructure ( user.fullName, {-hint text="age:"-}123 )
-
-
-destructure ( { first }, age ) =
-    first ++ ": " ++ String.fromInt age
-""")
-    fun `test as clause name overrides custom type variant name`() = checkByText("""module Foo exposing (..)
-
-example =
-    unfollowButton {-hint text="toMsg:"-}ClickedUnfollow {-hint text="cred:"-}cred {-hint text="author:"-}selected
-    
-unfollowButton toMsg cred ((FollowedAuthor uname _) as author) =
-    toggleFollowButton "Unfollow"
-        [ "btn-secondary" ]
-        (toMsg cred author)
-        uname
-""")
-
-
-    fun `test doesn't show hints for unit destructure`() = checkByText("""module Foo exposing (..)
-
-example =
-    destructureUnit ()
-
-
-destructureUnit () =
-    ()
-""")
-
-    fun `test type hint`() = checkByText("""module Foo exposing (..)
-
-example () =
-    call {-hint text="fn:"-}(\(greeting{-hint text=": String"-}, name{-hint text=": String"-}) -> greeting ++ ", " ++ name ) {-hint text="value:"-}("Hello", "World")
-
-call fn value = 
-    fn value
+    (\(greeting{-hint text=": String"-}, name{-hint text=": String"-}) -> greeting ++ ", " ++ name ) ("Hello", "World")
 """)
 
     fun `test let binding type hint`() = checkByText("""module Foo exposing (..)
 
-example =
+example ={-hint text=" -- Float"-}
     let
         foo ={-hint text=" -- Float"-}
             3.14
@@ -137,6 +29,7 @@ example =
 
     fun `test no hint for annotated let binding`() = checkByText("""module Foo exposing (..)
 
+example : List Float
 example =
     let
         foo : List Float
@@ -154,6 +47,13 @@ example =
             123 + ""
     in
     foo
+""")
+
+    fun `test show annotation for top-level definitions`() = checkByText("""module Foo exposing (..)
+ 
+
+example ={-hint text=" -- String"-}
+    "Hello!"
 """)
 
     @Suppress("UnstableApiUsage")

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -23,7 +23,7 @@ greeting =
 
 example =
     nameToString
-        {-hint text="{ first, last }:"-}{ first = "Jane"
+        { first = "Jane"
         , last = "Doe"
         }
 

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -55,6 +55,12 @@ example =
 example ={-hint text=" -- String"-}
     "Hello!"
 """)
+    fun `test show type annotation next to pattern matched values`() = checkByText("""module Foo exposing (..)
+ 
+greet : { first : String, last : String, age : Int } -> String
+greet { first{-hint text=": String"-}, age{-hint text=": Int"-} }=
+    "Hello " ++ first ++ "!"
+""")
 
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -74,15 +74,14 @@ destructureAs ((Bar n)) =
     "Foo"
 """)
 
-    fun `test record destructuring nested within tuple destructuring`() = checkByText("""module Foo exposing (..)
-
+    fun `test show pattern matched value name inline`() = checkByText("""module Foo exposing (..)
 
 example3 =
-    destructure {-hint text="( { first }, n ):"-}( { first = "first", last = "last" }, 123 )
+    destructure ( { first = "first", last = "last" }, {-hint text="age:"-}123 )
 
 
-destructure ( { first }, n ) =
-    first
+destructure ( { first }, age ) =
+    first ++ ": " ++ String.fromInt age
 """)
 
     @Suppress("UnstableApiUsage")

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -83,6 +83,17 @@ example3 user =
 destructure ( { first }, age ) =
     first ++ ": " ++ String.fromInt age
 """)
+    fun `test as clause name overrides custom type variant name`() = checkByText("""module Foo exposing (..)
+
+example =
+    unfollowButton {-hint text="toMsg:"-}ClickedUnfollow {-hint text="cred:"-}cred {-hint text="author:"-}selected
+    
+unfollowButton toMsg cred ((FollowedAuthor uname _) as author) =
+    toggleFollowButton "Unfollow"
+        [ "btn-secondary" ]
+        (toMsg cred author)
+        uname
+""")
 
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.elm.ide.hints.parameter
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import org.elm.lang.ElmTestBase
+import org.intellij.lang.annotations.Language
+
+class ElmInlayParameterHintsProviderTest : ElmTestBase() {
+    fun `test fn args`() = checkByText("""module Foo exposing (..)
+
+greet first last = "Hello " ++ first ++ " " ++ last
+
+greeting =
+    greet {-hint text="first:"-}"Jane" {-hint text="last:"-}"Doe"
+
+""")
+
+    @Suppress("UnstableApiUsage")
+    private fun checkByText(@Language("Elm") code: String) {
+        InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))
+
+        ElmInlayParameterHints.enabledOption.set(true)
+        ElmInlayParameterHints.smartOption.set(true)
+
+        myFixture.testInlays({ (it.renderer as HintRenderer).text }) { it.renderer is HintRenderer }
+    }
+
+    companion object {
+        private val HINT_COMMENT_PATTERN = Regex("""\{-(hint.*?)-\}""")
+    }
+}

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -146,6 +146,16 @@ example =
     foo
 """)
 
+    fun `test don't show type hint when unknown`() = checkByText("""module Foo exposing (..)
+
+example =
+    let
+        foo =
+            123 + ""
+    in
+    foo
+""")
+
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -57,7 +57,7 @@ type Element = Element Internals
 type alias Internals = { x: Int, y: Int }
 
 example value=
-    destructureVariant {-hint text="Element:"-}value
+    destructureVariant value
 
 
 destructureVariant (Element internals) =
@@ -66,12 +66,11 @@ destructureVariant (Element internals) =
 
     fun `test it discards nested parens in pattern expressions`() = checkByText("""module Foo exposing (..)
 
-example5 =
-    destructureAs {-hint text="Bar:"-}(Bar 123)
+example3 =
+    toString ( {-hint text="x:"-}123, {-hint text="y:"-}456)
 
-
-destructureAs ((Bar n)) =
-    "Foo"
+toString (((x,y))) =
+    String.fromInt x ++ ", " ++ String.fromInt y
 """)
 
     fun `test show pattern matched value name inline`() = checkByText("""module Foo exposing (..)

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -63,6 +63,16 @@ example value=
 destructureVariant (Element internals) =
     "Example"
 """)
+
+    fun `test it discards nested parens in pattern expressions`() = checkByText("""module Foo exposing (..)
+
+example5 =
+    destructureAs {-hint text="Bar:"-}(Bar 123)
+
+
+destructureAs ((Bar n)) =
+    "Foo"
+""")
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -42,6 +42,17 @@ getUserId _ retry =
     getUserIdHttpRequest retry
 """)
 
+    fun `test single constructor argument destructure`() = checkByText("""module Foo exposing (..)
+
+example user =
+    tokenHeader <hint text="token:"/>user.credentials
+
+type Token = Token String
+
+tokenHeader : Token -> Cmd msg
+tokenHeader (Token token) =
+    header "token" token
+""")
 
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -105,6 +105,17 @@ unfollowButton toMsg cred ((FollowedAuthor uname _) as author) =
         uname
 """)
 
+
+    fun `test doesn't show hints for unit destructure`() = checkByText("""module Foo exposing (..)
+
+example =
+    destructureUnit ()
+
+
+destructureUnit () =
+    ()
+""")
+
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -23,7 +23,7 @@ greeting =
 
 example =
     nameToString
-        { first = "Jane"
+        {-hint text="{ first, last }:"-}{ first = "Jane"
         , last = "Doe"
         }
 
@@ -73,6 +73,18 @@ example5 =
 destructureAs ((Bar n)) =
     "Foo"
 """)
+
+    fun `test record destructuring nested within tuple destructuring`() = checkByText("""module Foo exposing (..)
+
+
+example3 =
+    destructure {-hint text="( { first }, n ):"-}( { first = "first", last = "last" }, 123 )
+
+
+destructure ( { first }, n ) =
+    first
+""")
+
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -19,6 +19,30 @@ greeting =
 
 """)
 
+    fun `test no hints for destructured record arguments`() = checkByText("""module Foo exposing (..)
+
+example =
+    nameToString
+        { first = "Jane"
+        , last = "Doe"
+        }
+
+
+nameToString { first, last } =
+    first ++ " " ++ last
+""")
+
+    fun `test no hints for discarded arguments`() = checkByText("""module Foo exposing (..)
+
+example =
+    getUserId token <hint text="retry:"/>True
+
+getUserId : Token -> Bool -> Cmd msg
+getUserId _ retry =
+    getUserIdHttpRequest retry
+""")
+
+
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -125,6 +125,16 @@ call fn value =
     fn value
 """)
 
+    fun `test let binding type hint`() = checkByText("""module Foo exposing (..)
+
+example =
+    let
+        foo ={-hint text=" -- Float"-}
+            3.14
+    in
+    foo
+""")
+
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -54,6 +54,14 @@ tokenHeader (Token token) =
     header "token" token
 """)
 
+    fun `test uses name from top-level as clause`() = checkByText("""module Foo exposing (..)
+example =
+    coordinatesToString {-hint text="coordinates:"-}( 1, 2 )
+
+coordinatesToString (( x, y ) as coordinates) =
+    String.fromInt x ++ ", " ++ String.fromInt y
+""")
+
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -42,18 +42,6 @@ getUserId _ retry =
     getUserIdHttpRequest retry
 """)
 
-    fun `test single constructor argument destructure`() = checkByText("""module Foo exposing (..)
-
-example user =
-    tokenHeader <hint text="token:"/>user.credentials
-
-type Token = Token String
-
-tokenHeader : Token -> Cmd msg
-tokenHeader (Token token) =
-    header "token" token
-""")
-
     fun `test uses name from top-level as clause`() = checkByText("""module Foo exposing (..)
 example =
     coordinatesToString {-hint text="coordinates:"-}( 1, 2 )
@@ -62,6 +50,19 @@ coordinatesToString (( x, y ) as coordinates) =
     String.fromInt x ++ ", " ++ String.fromInt y
 """)
 
+    fun `test uses variant name when destructuring custom type`() = checkByText("""module Foo exposing (..)
+
+type Element = Element Internals
+
+type alias Internals = { x: Int, y: Int }
+
+example value=
+    destructureVariant {-hint text="Element:"-}value
+
+
+destructureVariant (Element internals) =
+    "Example"
+""")
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -76,8 +76,8 @@ destructureAs ((Bar n)) =
 
     fun `test show pattern matched value name inline`() = checkByText("""module Foo exposing (..)
 
-example3 =
-    destructure ( { first = "first", last = "last" }, {-hint text="age:"-}123 )
+example3 user =
+    destructure ( {-hint text="{ first }:"-}user.fullName, {-hint text="age:"-}123 )
 
 
 destructure ( { first }, age ) =

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -116,6 +116,15 @@ destructureUnit () =
     ()
 """)
 
+    fun `test type hint`() = checkByText("""module Foo exposing (..)
+
+example () =
+    call {-hint text="fn:"-}(\(greeting{-hint text=": String"-}, name{-hint text=": String"-}) -> greeting ++ ", " ++ name ) {-hint text="value:"-}("Hello", "World")
+
+call fn value = 
+    fn value
+""")
+
     @Suppress("UnstableApiUsage")
     private fun checkByText(@Language("Elm") code: String) {
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -61,8 +61,6 @@ example ={-hint text=" -- String"-}
         InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))
 
         ElmInlayParameterHints.enabledOption.set(true)
-        ElmInlayParameterHints.smartOption.set(true)
-
         myFixture.testInlays({ (it.renderer as HintRenderer).text }) { it.renderer is HintRenderer }
     }
 

--- a/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/hints/parameter/ElmInlayParameterHintsProviderTest.kt
@@ -32,6 +32,17 @@ nameToString { first, last } =
     first ++ " " ++ last
 """)
 
+    fun `test no hints for nested record destructuring`() = checkByText("""module Foo exposing (..)
+
+example =
+    nameToString ( (), { first = "Jane" , last = "Doe" } )
+
+
+nameToString (_, { first, last }) =
+    first ++ " " ++ last
+""")
+
+
     fun `test no hints for discarded arguments`() = checkByText("""module Foo exposing (..)
 
 example =
@@ -76,7 +87,7 @@ toString (((x,y))) =
     fun `test show pattern matched value name inline`() = checkByText("""module Foo exposing (..)
 
 example3 user =
-    destructure ( {-hint text="{ first }:"-}user.fullName, {-hint text="age:"-}123 )
+    destructure ( user.fullName, {-hint text="age:"-}123 )
 
 
 destructure ( { first }, age ) =


### PR DESCRIPTION
Hello! I was playing around with an inlay parameter hint provider, inspired by the [`intellij-rust`](https://github.com/intellij-rust/intellij-rust/blob/master/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProvider.kt) implementation.

I wanted to get an initial version to you for feedback, along with some notes of the current behavior and some future possibilities. It turns out, this all worked out quite smoothly, although there are some interesting cases that I note below. Overall, I think this is pretty interesting with the current cases implemented as is, and we can iterate and refine from there.

I have a few todos that I'd like to take care of before merging that I've written out below as well. If you think of anything else, let me know and I'll add it to the list.

## Cases


### Pipelines
Right now, I'm now showing hints for pipelines. This is a good thing in general, because usually the argument that you're piping through is understood to be the subject of the pipeline, so it doesn't need a name.

<img width="292" alt="Image 2020-08-01 at 6 38 42 PM" src="https://user-images.githubusercontent.com/1384166/89113485-7f6e4400-d426-11ea-8f58-223e3bd2f9e8.png">


### Destructured names

#### Destructuring a Custom Type with a single constructor value

Shows a hint with the destructured name.

<img width="339" alt="Image 2020-08-01 at 6 34 10 PM" src="https://user-images.githubusercontent.com/1384166/89113488-86955200-d426-11ea-96fb-f042ba3153d3.png">

#### Destructuring records
I believe the best way to handle these cases would be to not show a hint at all for these arguments:
```elm
example =
    nameToString
        { first = "Jane"
        , last = "Doe"
        }


nameToString { first, last } =
    first ++ " " ++ last

```

This is on my todo list, because right now it's using one of the destructured names, but that's not accurate (whether there is only one value destructured, or more than one as in the above example).

## Cases with no hint

### Point-free definitions
#### Underlying kernel function
It turns out, quite a few of the standard library definitions use this point free style. Like `Decode.map`, for example.

```elm
map : (a -> value) -> Decoder a -> Decoder value
map =
    Elm.Kernel.Json.map1
```

For cases like this, I don't think there's much you can do since it's defined in the kernel.

#### Non-Kernel point-free definitions
Longer term, if a function is point-free, but its underlying definition is non-kernel code, we can look at the argument name one level deeper. For example:

```elm
example =
    heading "This is content" "This is postfix"
            -- ^ content
                                       -- ^ postfix

heading =
    combine "Heading:"

combine prefix content postfix =
    prefix ++ "\n" ++ content ++ "\n" ++ postfix
```

We can infer those values that I annotated. I think it makes sense to defer this to a future pull request, after we see how it goes with the first set of functionality, though.


## Remaining TODOs

- [x] Don't show hints for destructured records (including 1 argument, don't show for any of these cases)
- [ ] Hide hints for arguments that only have a single argument
- [ ] Don't show hints for arguments that end with the passed in variable name
- [x] Don't show hints for parameters named `_`

## Future possibilities

#### Pipeline type names
Show the types along the way in the pipeline. Sometimes it's hard to keep track of the intermediary types, and there's prior art. See https://www.jetbrains.com/help/rider/Inline_Parameter_Name_Hints.html#type-name-hints

![image](https://user-images.githubusercontent.com/1384166/89113513-0cb19880-d427-11ea-8b7e-ddb85646ca97.png)


#### Applicative pipeline field names
I think it could solve a real problem that comes up a lot that it's hard to tell which decoder value will map to which record value because of the positional nature of pipelines. [This recent Discourse thread](https://discourse.elm-lang.org/t/about-the-ergonomics-of-applicative-json-decoding/6099/14) discusses it, and there have been many similar discussions in the past.

#### Lambda type hints
As with the Rider IDE, we could display type hints for lambdas. I often get confused when I'm writing a `foldl` expression, for example, and can't keep the order of the arguments straight. Having the type names would help for this kind of case.

Here's what it looks like in Rider (see https://www.jetbrains.com/help/rider/Inline_Parameter_Name_Hints.html#type-name-hints)

![image](https://user-images.githubusercontent.com/1384166/89114676-1261ab00-d434-11ea-9366-473eed67902f.png)
