### PR TITLE
Restricts the InlineDebugIntention from showing in several cases

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionCallExpr.kt
+++ b/src/main/kotlin/org/elm/lang/core/psi/elements/ElmFunctionCallExpr.kt
@@ -31,4 +31,17 @@ class ElmFunctionCallExpr(node: ASTNode) : ElmPsiElementImpl(node), ElmExpressio
     val arguments: Sequence<ElmAtomTag>
         get() =
             directChildren.filterIsInstance<ElmAtomTag>().drop(1)
+
+    /** The arguments to the function, but with parenthesized expressions unwrapped */
+    val argumentsWithoutParens: Sequence<ElmExpressionTag>
+        get() =
+            arguments
+                    .map {
+                        if (it is ElmParenthesizedExpr) {
+                            it.expression
+                        } else {
+                            it
+                        }
+                    }
+                    .filterNotNull()
 }

--- a/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/ElmIntentionTestBase.kt
@@ -9,6 +9,7 @@ package org.elm.ide.intentions
 
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.testFramework.PlatformTestUtil
+import junit.framework.ComparisonFailure
 import org.elm.fileTreeFromText
 import org.elm.lang.ElmTestBase
 import org.intellij.lang.annotations.Language
@@ -16,10 +17,13 @@ import org.intellij.lang.annotations.Language
 
 abstract class ElmIntentionTestBase(val intention: IntentionAction) : ElmTestBase() {
 
-    protected fun doAvailableTest(@Language("Elm") before: String, @Language("Elm") after: String) {
+    protected fun doAvailableTest(@Language("Elm") before: String, @Language("Elm") after: String, expectedIntentionText: String? = null) {
         InlineFile(before).withCaret()
         launchAction()
         myFixture.checkResult(replaceCaretMarker(after))
+        if (expectedIntentionText != null && expectedIntentionText != intention.text) {
+            throw ComparisonFailure("Intention text did not match", expectedIntentionText, intention.text)
+        }
     }
 
     protected fun doAvailableTestWithFileTree(@Language("Elm") fileStructureBefore: String, @Language("Elm") openedFileAfter: String) {

--- a/src/test/kotlin/org/elm/ide/intentions/InlineDebugIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/InlineDebugIntentionTest.kt
@@ -112,7 +112,7 @@ f0 =
 
 f1 = 
     case f0 of
-        _ -> 1{-caret-}
+        _ -> 1 + 1{-caret-}
 """, """
 module Foo exposing (f0)
 f0 =
@@ -120,7 +120,7 @@ f0 =
 
 f1 = 
     case f0 of
-        _ -> (Debug.log "1" (1))
+        _ -> (Debug.log "1 + 1" (1 + 1))
 """)
 
     fun `test debugging case on function call`() = doAvailableTest(
@@ -142,15 +142,19 @@ f1 =
         _ -> 1
 """)
 
-    fun `test debugging binary operator input`() = doAvailableTest(
+    fun `test debugging constants with binary operators`() = doAvailableTest(
             """
 module Foo exposing (f0)
+f1 = 1
+
 f0 = 
-    1 + 1{-caret-}
+    1 + f1{-caret-}
 """, """
 module Foo exposing (f0)
+f1 = 1
+
 f0 = 
-    1 + (Debug.log "1" (1))
+    1 + (Debug.log "f1" (f1))
 """)
 
     fun `test debugging binary operator operation`() = doAvailableTest(
@@ -215,15 +219,113 @@ f0 =
     )
 """)
 
-    fun `test debugging function composition`() = doAvailableTest(
+    fun `test debugging function composition`() = doUnavailableTest(
             """
 module Foo exposing (f0)
 f0 = 
     (+) 1 >> String.fr{-caret-}omInt
+""")
+
+    fun `test debugging log statements`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    Debug.l{-caret-}og "hello" "hello"
+""")
+
+    fun `test debugging log arguments`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    Debug.log "hello" (2 + 2){-caret-}
+""")
+
+    fun `test debugging ignoring nested log function calls`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    Debug.log "hello" (List.ma{-caret-}p identity [ 0 ])
+""")
+
+    fun `test debugging arguments for nested log function calls`() = doAvailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    Debug.log "hello" (List.map ident{-caret-}ity [ 0 ])
 """, """
 module Foo exposing (f0)
 f0 = 
-    (+) 1 >> String.fromInt
+    Debug.log "hello" (List.map (Debug.log "identity" (identity)) [ 0 ])
+""")
+
+    fun `test debugging nested log function calls with binary operators`() = doAvailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    Debug.log "hello" (2 + ({-caret-}1 + 1))
+""", """
+module Foo exposing (f0)
+f0 = 
+    Debug.log "hello" (2 + ((Debug.log "1 + 1" (1 + 1))))
+""")
+
+    fun `test debugging todo statements`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    Debug.tod{-caret-}o "hello"
+""")
+
+    fun `test debugging todo arguments`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    Debug.todo (2 + 2){-caret-}
+""")
+
+    fun `test debugging string literals`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    "he{-caret-}llo"
+""")
+
+    fun `test debugging char literals`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    'e{-caret-}'
+""")
+
+    fun `test debugging numeric literals`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    1{-caret-}
+""")
+
+    fun `test debugging float literals`() = doUnavailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    1{-caret-}.2
+""")
+
+    fun `test debugging constants`() = doAvailableTest(
+            """
+module Foo exposing (f0)
+f0 = 
+    1
+    
+f1 =
+    f0{-caret-}
+""", """
+module Foo exposing (f0)
+f0 = 
+    1
+    
+f1 =
+    (Debug.log "f0" (f0))
 """)
 
 }

--- a/src/test/kotlin/org/elm/ide/intentions/InlineDebugIntentionTest.kt
+++ b/src/test/kotlin/org/elm/ide/intentions/InlineDebugIntentionTest.kt
@@ -13,7 +13,8 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     List.map f (Debug.log "items" (items))
-""")
+""",
+            "Debug.log this value")
 
     fun `test debugging function call`() = doAvailableTest(
             """
@@ -24,10 +25,11 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     (Debug.log "List.map f items" (List.map f items))
-""")
+""",
+            "Debug.log output of function")
 
     fun `test debugging expr with double quotes`() = doAvailableTest(
-        """
+            """
 module Foo exposing (f0)
 f0 = 
     Str{-caret-}ing.length "foo"
@@ -35,7 +37,8 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     (Debug.log "String.length \"foo\"" (String.length "foo"))
-""")
+""",
+            "Debug.log output of function")
 
     fun `test debugging pattern matching input`() = doAvailableTest(
             """
@@ -54,7 +57,8 @@ f0 =
 f1 = 
     case (Debug.log "f0" (f0)) of
         _ -> 1
-""")
+""",
+            "Debug.log this value")
 
     fun `test debugging pattern matching output`() = doAvailableTest(
             """
@@ -78,7 +82,8 @@ f1 =
                 _ -> 1
         )
     )
-""")
+""",
+            "Debug.log output of case statement")
 
     fun `test debugging case branch`() = doAvailableTest(
             """
@@ -102,7 +107,8 @@ f1 =
                 _ -> 1
         )
     )
-""")
+""",
+            "Debug.log output of case statement")
 
     fun `test debugging case branch value`() = doAvailableTest(
             """
@@ -121,9 +127,10 @@ f0 =
 f1 = 
     case f0 of
         _ -> (Debug.log "1 + 1" (1 + 1))
-""")
+""",
+            "Debug.log expression")
 
-    fun `test debugging case on function call`() = doAvailableTest(
+    fun `test debugging case on function`() = doAvailableTest(
             """
 module Foo exposing (f0)
 f0 _ =
@@ -140,7 +147,8 @@ f0 _ =
 f1 = 
     case ((Debug.log "f0 42" (f0 42))) of
         _ -> 1
-""")
+""",
+            "Debug.log output of function")
 
     fun `test debugging constants with binary operators`() = doAvailableTest(
             """
@@ -155,7 +163,8 @@ f1 = 1
 
 f0 = 
     1 + (Debug.log "f1" (f1))
-""")
+""",
+            "Debug.log this value")
 
     fun `test debugging binary operator operation`() = doAvailableTest(
             """
@@ -166,7 +175,8 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     (Debug.log "1 + 1" (1 + 1))
-""")
+""",
+            "Debug.log expression")
 
     fun `test debugging multiple binary operator operations`() = doAvailableTest(
             """
@@ -177,7 +187,8 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     (Debug.log "1 + 1 + 1" (1 + 1 + 1))
-""")
+""",
+            "Debug.log expression")
 
     fun `test debugging piped operations`() = doAvailableTest(
             """
@@ -188,7 +199,8 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     (Debug.log "1 + 1 + 1 |> (+) 1" (1 + 1 + 1 |> (+) 1))
-""")
+""",
+            "Debug.log output of pipeline")
 
     fun `test debugging piped operations with function`() = doAvailableTest(
             """
@@ -199,7 +211,8 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     (Debug.log "1 + 1 + 1 |> String.fromInt" (1 + 1 + 1 |> String.fromInt))
-""")
+""",
+            "Debug.log output of pipeline")
 
     fun `test debugging multiline piped operations with function`() = doAvailableTest(
             """
@@ -217,7 +230,8 @@ f0 =
                 |> String.fromInt
         )
     )
-""")
+""",
+            "Debug.log output of pipeline")
 
     fun `test debugging function composition`() = doUnavailableTest(
             """
@@ -256,7 +270,8 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     Debug.log "hello" (List.map (Debug.log "identity" (identity)) [ 0 ])
-""")
+""",
+            "Debug.log this value")
 
     fun `test debugging nested log function calls with binary operators`() = doAvailableTest(
             """
@@ -267,7 +282,8 @@ f0 =
 module Foo exposing (f0)
 f0 = 
     Debug.log "hello" (2 + ((Debug.log "1 + 1" (1 + 1))))
-""")
+""",
+            "Debug.log expression")
 
     fun `test debugging todo statements`() = doUnavailableTest(
             """
@@ -326,6 +342,7 @@ f0 =
     
 f1 =
     (Debug.log "f0" (f0))
-""")
+""",
+            "Debug.log this value")
 
 }


### PR DESCRIPTION
I recommend reviewing this commit by commit.

To provide a better user experience, the intention should not be shown as an option to the user, if it cannot do something valuable. This commit restricts the intention from showing in these cases:

 * On string, numeric, and char literals (unless the literal is part of a binary operator expression, in which case, THAT expression is logged).
 * On calls and arguments to Debug functions

This PR also adds dynamic text to the intention, to better tell the user what it is that will be debugged when they apply the intention. This is also a prelude of sorts for removing `Debug.log` statements. This intention can now detect if a statement is already being `Debug.log`ed, so in the future, I can let it remove the `Debug.log` in that case, instead of just making the intention unavailable.