### PR TITLE
Improves handling of parentheses in IncompletePatternInspection

### DIFF
--- a/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmIncompletePatternInspectionTest.kt
@@ -90,6 +90,137 @@ foo it =
             --EOL
 """)
 
+//    fun `test no existing branch in parenthesis`() = checkFixByText("Add missing case branches", """
+//type Foo = Bar | Baz | Qux
+//
+//foo : Foo -> ()
+//foo it =
+//    (<error>case{-caret-}</error> it of<error>)</error>
+//""", """
+//type Foo = Bar | Baz | Qux
+//
+//foo : Foo -> ()
+//foo it =
+//    (case it of
+//        Bar ->
+//            --EOL
+//
+//        Baz ->
+//            --EOL
+//
+//        Qux ->
+//            --EOL
+//    )
+//""")
+
+//    fun `test one existing branch in parenthesis`() = checkFixByText("Add missing case branches", """
+//type Foo = Bar | Baz | Qux
+//
+//foo : Foo -> ()
+//foo it =
+//    (<error>case{-caret-}</error> it of
+//        Baz ->
+//            ()<error>)</error>
+//""", """
+//type Foo = Bar | Baz | Qux
+//
+//foo : Foo -> ()
+//foo it =
+//    (case it of
+//        Baz ->
+//            ()
+//
+//        Bar ->
+//            --EOL
+//
+//        Qux ->
+//            --EOL
+//    )
+//""")
+
+    fun `test one existing branch in parenthesis on new line`() = checkFixByText("Add missing case branches", """
+type Foo = Bar | Baz | Qux
+
+foo : Foo -> ()
+foo it =
+    (<error>case{-caret-}</error> it of
+        Baz ->
+            ()
+    )
+""", """
+type Foo = Bar | Baz | Qux
+
+foo : Foo -> ()
+foo it =
+    (case it of
+        Baz ->
+            ()
+
+        Bar ->
+            --EOL
+
+        Qux ->
+            --EOL
+    )
+""")
+
+//    fun `test two existing branches in parenthesis`() = checkFixByText("Add missing case branches", """
+//type Foo = Bar | Baz | Qux
+//
+//foo : Foo -> ()
+//foo it =
+//    (<error>case{-caret-}</error> it of
+//        Baz ->
+//            ()
+//
+//        Qux ->
+//            ()<error>)</error>
+//""", """
+//type Foo = Bar | Baz | Qux
+//
+//foo : Foo -> ()
+//foo it =
+//    (case it of
+//        Baz ->
+//            ()
+//
+//        Qux ->
+//            ()
+//
+//        Bar ->
+//            --EOL
+//    )
+//""")
+
+    fun `test two existing branches in parenthesis on new line`() = checkFixByText("Add missing case branches", """
+type Foo = Bar | Baz | Qux
+
+foo : Foo -> ()
+foo it =
+    (<error>case{-caret-}</error> it of
+        Baz ->
+            ()
+
+        Qux ->
+            ()
+    )
+""", """
+type Foo = Bar | Baz | Qux
+
+foo : Foo -> ()
+foo it =
+    (case it of
+        Baz ->
+            ()
+
+        Qux ->
+            ()
+
+        Bar ->
+            --EOL
+    )
+""")
+
     fun `test params`() = checkFixByText("Add missing case branches", """
 type Foo = Foo
 type alias BarBaz = Foo


### PR DESCRIPTION
When using the inspection to add missing branches to my `case` statements, I've often run into annoyances when my `case` is wrapped in parentheses in some way. This PR improves handling of parentheses in some cases, but it's also incomplete, and I need some help to get it where I would like it to go. I've added test cases and described how each of them have changed from the old code to the new. The commented-out tests are ones that fail, and I would like to fix.

The primary reason I couldn't get some tests to work, is that there seems to be an issue with the parser. All the failing cases involve an incomplete `case` statement being wrapped in parentheses, with the closing parenthesis being right next to the final character in the incomplete `case`. The basic test is that of `(case it of)`, where the parser produces an `ElmParenthesizedExpr` wrapping an `ElmCaseOfExpr` as expected, but the closing parenthesis is included in the `ElmCaseOfExpr`, like so:

    caseOfExpr.text == "case it of)"

It's the same issue with the other failing tests, where the closing parenthesis sits at the end of a branch. Note that having the closing parenthesis at the end of the branch is actually valid Elm code, so the parser is also rejecting valid Elm code as it is now. I tried diving into it, but that was also a rabbit hole too far for me at the moment. If you could provide some guidance on what to do, I could maybe give it a shot :slightly_smiling_face: I think it's also fair to reject this work, if you don't think it's worth the cost of making that change.

PS: Sorry about laying all these PRs on you during the holidays. Don't worry about timing, I'll wait for whenever it suits you :blush: