### PR TITLE
Add spacing around parens in tuples

### DIFF
--- a/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeRendering.kt
@@ -92,7 +92,7 @@ private class TypeRenderer(
     }
 
     private fun renderTuple(ty: TyTuple): String {
-        return ty.types.joinToString(", ", prefix = "(", postfix = ")") { render(it) }
+        return ty.types.joinToString(", ", prefix = "( ", postfix = " )") { render(it) }
     }
 
     private fun AliasInfo.renderedText(): String {

--- a/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/elm/ide/docs/ElmQuickDocumentationTest.kt
@@ -53,7 +53,7 @@ main = foo
       --^
 """,
             """
-<div class='definition'><pre><b>foo</b> : number → ((), <a href="psi_element://String">String</a>, number)
+<div class='definition'><pre><b>foo</b> : number → ( (), <a href="psi_element://String">String</a>, number )
 <b>foo</b> a</pre></div>
 """)
 

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest1.kt
@@ -78,7 +78,7 @@ main foo =
 
     fun `test mismatched tuple value type from missing field`() = checkByText("""
 main : ((), (), ())
-main = <error descr="Type mismatch.Required: ((), (), ())Found: ((), ())">((), ())</error>
+main = <error descr="Type mismatch.Required: ( (), (), () )Found: ( (), () )">((), ())</error>
 """)
 
     fun `test mismatched tuple value type from wrong field type`() = checkByText("""
@@ -88,7 +88,7 @@ main = (<error descr="Type mismatch.Required: ()Found: Float">1.0</error>, ())
 
     fun `test mismatched tuple value type from extra field`() = checkByText("""
 main : ((), ())
-main = <error descr="Type mismatch.Required: ((), ())Found: ((), (), ())">((), (), ())</error>
+main = <error descr="Type mismatch.Required: ( (), () )Found: ( (), (), () )">((), (), ())</error>
 """)
 
     fun `test matched tuple value type`() = checkByText("""

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest2.kt
@@ -67,7 +67,7 @@ main =
 main : ()
 main =
     let
-        <error descr="Invalid pattern.Required type: ((), ())Pattern type: (a, b, c)">(x, y, z)</error> = ((), ())
+        <error descr="Invalid pattern.Required type: ( (), () )Pattern type: ( a, b, c )">(x, y, z)</error> = ((), ())
     in
         y
 """)
@@ -76,7 +76,7 @@ main =
 main : ()
 main =
     let
-        <error descr="Invalid pattern.Required type: ((), (), ())Pattern type: (a, b)">(x, y)</error> = ((), (), ())
+        <error descr="Invalid pattern.Required type: ( (), (), () )Pattern type: ( a, b )">(x, y)</error> = ((), (), ())
     in
         y
 """)
@@ -160,7 +160,7 @@ main =
 main : ()
 main =
     let
-        <error descr="Invalid pattern.Required type: ()Pattern type: (a, b)">(x, y)</error> = ()
+        <error descr="Invalid pattern.Required type: ()Pattern type: ( a, b )">(x, y)</error> = ()
     in
         y
 """)

--- a/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/inference/TypeInferenceInspectionTest3.kt
@@ -444,7 +444,7 @@ foo a b = a
 
 main : (number, number) -> (number, number) -> ()
 main a b =
-    <error descr="Type mismatch.Required: ()Found: (number, number)">foo a b</error>
+    <error descr="Type mismatch.Required: ()Found: ( number, number )">foo a b</error>
 """)
 
     fun `test constraint comparable tuple float`() = checkByText("""
@@ -453,7 +453,7 @@ foo a b = a
 
 main : ()
 main =
-    <error descr="Type mismatch.Required: ()Found: (Float, Float)">foo (1.1, 2.2) (3.3, 4.4)</error>
+    <error descr="Type mismatch.Required: ()Found: ( Float, Float )">foo (1.1, 2.2) (3.3, 4.4)</error>
 """)
 
     fun `test constraint comparable appendable mismatch`() = checkByText("""
@@ -471,7 +471,7 @@ foo a b = a
 
 main : ()
 main =
-    foo ("", "") <error descr="Type mismatch.Required: (String, String)Found: (String, Float)">("", 1.1)</error>
+    foo ("", "") <error descr="Type mismatch.Required: ( String, String )Found: ( String, Float )">("", 1.1)</error>
 """)
 
     fun `test constraint comparable comparable`() = checkByText("""
@@ -665,7 +665,7 @@ foo a = ((), "", a + 1)
 
 main : ()
 main =
-    <error descr="Type mismatch.Required: ()Found: number → ((), String, number)">foo</error>
+    <error descr="Type mismatch.Required: ()Found: number → ( (), String, number )">foo</error>
 """)
 
     fun `test using constrained var in let`() = checkByText("""
@@ -738,7 +738,7 @@ main a =
             (x, ()) -> x
             _ -> ""
     in
-        ( foo <error descr="Type mismatch.Required: ()Found: (String, ())">a</error>
+        ( foo <error descr="Type mismatch.Required: ()Found: ( String, () )">a</error>
         , foo <error descr="Type mismatch.Required: ()Found: String">b</error>
         )
 """)
@@ -980,7 +980,7 @@ type Baz c d = Baz { f4 : Foo d -> Foo d }
 
 main : Baz (e -> ()) e -> Bar e
 main (Baz baz) =
-    Bar <error descr="Type mismatch.Required: { f2 : Foo ((), b) }Found: { f2 : Foo e }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ((), b)&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f2 = baz.f4 Foo }</error>
+    Bar <error descr="Type mismatch.Required: { f2 : Foo ( (), b ) }Found: { f2 : Foo e }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ( (), b )&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f2 = baz.f4 Foo }</error>
 """)
 
     fun `test flex arg to rigid param 2`() = checkByText("""
@@ -991,7 +991,7 @@ type Baz c d = Baz { f3 : c , f4 : Foo d -> Foo d }
 main : Baz (e -> ()) e -> Bar e
 main (Baz baz) =
     Bar
-        <error descr="Type mismatch.Required: { f1 : e → (), f2 : Foo ((), e) }Found: { f1 : e → (), f2 : Foo e }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ((), e)&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f1 = baz.f3
+        <error descr="Type mismatch.Required: { f1 : e → (), f2 : Foo ( (), e ) }Found: { f1 : e → (), f2 : Foo e }Mismatched fields: &nbsp;&nbsp;Field f2:&nbsp;&nbsp;&nbsp;&nbsp;Required: Foo ( (), e )&nbsp;&nbsp;&nbsp;&nbsp;Found: Foo e">{ f1 = baz.f3
         , f2 = baz.f4 Foo
         }</error>
 """)


### PR DESCRIPTION
I am used to generating the type, then saving and seeing the type change because `elm-format` re-formats the type annotation.

This change makes the type look more like what elm-format would format it to. Records also have this spacing so this would be consistent with that too.