### PR TITLE
Remove Lamdera notes that are no longer necessary

### DIFF
--- a/docs/features/lamdera.md
+++ b/docs/features/lamdera.md
@@ -8,20 +8,3 @@ A Lamdera project currently consists of:
 
 To get going, you can download Lamdera's compiler here:
 [Download lamdera executable](https://dashboard.lamdera.app/docs/download)
-
-
-## Tips for using `lamdera` executable as a compiler replacement for `elm`
-
-To correctly set up the local package path for Lamdera, you can do:
-
-`ln -s ~/.elm/0.19.1 ~/.elm/0.19.1-1.0.1`
-
-This plugin recognizes the Lamdera executable as a replacement for the elm executable in the plugin's settings:
-
-![](../assets/plugin-settings-lamda.png)
-
-
-### Known quirks
-
-On some Linux systems, the message `libtinfo.so.5: no version information available (required by lamdera)` appears with every `lamdera` command.
-There seems to be no easy solution, but until now, Lamdera works as expected despite this message. This plugin will skip this message when analyzing Lamdera's compiler output.


### PR DESCRIPTION
The latest version of Lamdera uses `~/.elm/0.19.1` again, and all linux builds are now statically built so shouldn't have any external lib dep issues anymore.

One thing I'm unsure about is whether we need to advise the user to set their elm path to the lamdera binary path? Or will intellij-elm automatically figure that out?